### PR TITLE
Tidy Perl imports

### DIFF
--- a/lib/WebService/PayPal/PaymentsAdvanced.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced.pm
@@ -8,9 +8,8 @@ our $VERSION = '0.000028';
 
 use feature qw( say state );
 
-use Data::GUID;
+use Data::GUID ();
 use List::AllUtils qw( any );
-use LWP::UserAgent;
 use MooX::StrictConstructor;
 use Type::Params qw( compile );
 use Types::Common::Numeric qw( PositiveNum );
@@ -27,32 +26,32 @@ use Types::Standard qw(
     Optional
 );
 use Types::URI qw( Uri );
-use URI;
-use URI::FromHash qw( uri uri_object );
+use URI ();
+use URI::FromHash qw( uri_object );
 use URI::QueryParam;
 
 #<<< don't perltidy
-use WebService::PayPal::PaymentsAdvanced::Error::Generic;
-use WebService::PayPal::PaymentsAdvanced::Error::HostedForm;
-use WebService::PayPal::PaymentsAdvanced::Response;
-use WebService::PayPal::PaymentsAdvanced::Response::Authorization;
-use WebService::PayPal::PaymentsAdvanced::Response::Authorization::CreditCard;
-use WebService::PayPal::PaymentsAdvanced::Response::Authorization::PayPal;
-use WebService::PayPal::PaymentsAdvanced::Response::Capture;
-use WebService::PayPal::PaymentsAdvanced::Response::Credit;
-use WebService::PayPal::PaymentsAdvanced::Response::FromHTTP;
-use WebService::PayPal::PaymentsAdvanced::Response::FromRedirect;
-use WebService::PayPal::PaymentsAdvanced::Response::FromSilentPOST;
-use WebService::PayPal::PaymentsAdvanced::Response::FromSilentPOST::CreditCard;
-use WebService::PayPal::PaymentsAdvanced::Response::FromSilentPOST::PayPal;
-use WebService::PayPal::PaymentsAdvanced::Response::Inquiry;
-use WebService::PayPal::PaymentsAdvanced::Response::Inquiry::CreditCard;
-use WebService::PayPal::PaymentsAdvanced::Response::Inquiry::PayPal;
-use WebService::PayPal::PaymentsAdvanced::Response::Sale;
-use WebService::PayPal::PaymentsAdvanced::Response::Sale::CreditCard;
-use WebService::PayPal::PaymentsAdvanced::Response::Sale::PayPal;
-use WebService::PayPal::PaymentsAdvanced::Response::SecureToken;
-use WebService::PayPal::PaymentsAdvanced::Response::Void;
+use WebService::PayPal::PaymentsAdvanced::Error::Generic ();
+use WebService::PayPal::PaymentsAdvanced::Error::HostedForm ();
+use WebService::PayPal::PaymentsAdvanced::Response ();
+use WebService::PayPal::PaymentsAdvanced::Response::Authorization ();
+use WebService::PayPal::PaymentsAdvanced::Response::Authorization::CreditCard ();
+use WebService::PayPal::PaymentsAdvanced::Response::Authorization::PayPal ();
+use WebService::PayPal::PaymentsAdvanced::Response::Capture ();
+use WebService::PayPal::PaymentsAdvanced::Response::Credit ();
+use WebService::PayPal::PaymentsAdvanced::Response::FromHTTP ();
+use WebService::PayPal::PaymentsAdvanced::Response::FromRedirect ();
+use WebService::PayPal::PaymentsAdvanced::Response::FromSilentPOST ();
+use WebService::PayPal::PaymentsAdvanced::Response::FromSilentPOST::CreditCard ();
+use WebService::PayPal::PaymentsAdvanced::Response::FromSilentPOST::PayPal ();
+use WebService::PayPal::PaymentsAdvanced::Response::Inquiry ();
+use WebService::PayPal::PaymentsAdvanced::Response::Inquiry::CreditCard ();
+use WebService::PayPal::PaymentsAdvanced::Response::Inquiry::PayPal ();
+use WebService::PayPal::PaymentsAdvanced::Response::Sale ();
+use WebService::PayPal::PaymentsAdvanced::Response::Sale::CreditCard ();
+use WebService::PayPal::PaymentsAdvanced::Response::Sale::PayPal ();
+use WebService::PayPal::PaymentsAdvanced::Response::SecureToken ();
+use WebService::PayPal::PaymentsAdvanced::Response::Void ();
 #>>>
 
 has nonfatal_result_codes => (

--- a/lib/WebService/PayPal/PaymentsAdvanced/Mocker.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Mocker.pm
@@ -7,8 +7,8 @@ use namespace::autoclean;
 our $VERSION = '0.000028';
 
 use Types::Standard qw( Bool CodeRef InstanceOf );
-use WebService::PayPal::PaymentsAdvanced::Mocker::PayflowLink;
-use WebService::PayPal::PaymentsAdvanced::Mocker::PayflowPro;
+use WebService::PayPal::PaymentsAdvanced::Mocker::PayflowLink ();
+use WebService::PayPal::PaymentsAdvanced::Mocker::PayflowPro  ();
 
 has mocked_ua => (
     is       => 'ro',

--- a/lib/WebService/PayPal/PaymentsAdvanced/Mocker/Helper.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Mocker/Helper.pm
@@ -6,10 +6,10 @@ use namespace::autoclean;
 
 our $VERSION = '0.000028';
 
-use Data::GUID;
-use DateTime;
-use DateTime::Format::MySQL;
-use DateTime::TimeZone;
+use Data::GUID              ();
+use DateTime                ();
+use DateTime::Format::MySQL ();
+use DateTime::TimeZone      ();
 use Types::Standard qw( InstanceOf );
 
 has _time_zone => (

--- a/lib/WebService/PayPal/PaymentsAdvanced/Mocker/PayflowPro.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Mocker/PayflowPro.pm
@@ -11,7 +11,7 @@ use feature qw( state );
 use Data::GUID ();
 use List::AllUtils qw( none );
 use URI::FromHash qw( uri_object );
-use WebService::PayPal::PaymentsAdvanced::Mocker::Helper;
+use WebService::PayPal::PaymentsAdvanced::Mocker::Helper ();
 
 my $helper = WebService::PayPal::PaymentsAdvanced::Mocker::Helper->new;
 

--- a/lib/WebService/PayPal/PaymentsAdvanced/Mocker/SilentPOST.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Mocker/SilentPOST.pm
@@ -8,7 +8,7 @@ our $VERSION = '0.000028';
 
 use Types::Common::String qw( NonEmptyStr );
 use Types::Standard qw( InstanceOf );
-use WebService::PayPal::PaymentsAdvanced::Mocker::Helper;
+use WebService::PayPal::PaymentsAdvanced::Mocker::Helper ();
 
 has _helper => (
     is  => 'lazy',

--- a/lib/WebService/PayPal/PaymentsAdvanced/Response.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Response.pm
@@ -9,8 +9,8 @@ our $VERSION = '0.000028';
 use List::AllUtils qw( any );
 use Types::Common::String qw( NonEmptyStr );
 use Types::Standard qw( ArrayRef Int Maybe );
-use WebService::PayPal::PaymentsAdvanced::Error::Authentication;
-use WebService::PayPal::PaymentsAdvanced::Error::Generic;
+use WebService::PayPal::PaymentsAdvanced::Error::Authentication ();
+use WebService::PayPal::PaymentsAdvanced::Error::Generic ();
 
 has _nonfatal_result_codes => (
     init_arg => 'nonfatal_result_codes',

--- a/lib/WebService/PayPal/PaymentsAdvanced/Response/FromHTTP.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Response/FromHTTP.pm
@@ -6,13 +6,12 @@ use namespace::autoclean;
 
 our $VERSION = '0.000028';
 
-use MooX::HandlesVia;
 use MooX::StrictConstructor;
 use Types::Standard qw( HashRef InstanceOf );
 use Types::URI qw( Uri );
-use URI;
+use URI ();
 use URI::QueryParam;
-use WebService::PayPal::PaymentsAdvanced::Error::HTTP;
+use WebService::PayPal::PaymentsAdvanced::Error::HTTP ();
 
 # Don't use HasParams role as we want to build params rather than require them.
 

--- a/lib/WebService/PayPal/PaymentsAdvanced/Response/FromSilentPOST.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Response/FromSilentPOST.pm
@@ -8,14 +8,13 @@ our $VERSION = '0.000028';
 
 use Const::Fast qw( const );
 use List::AllUtils qw( any );
-use MooX::HandlesVia;
 use MooX::StrictConstructor;
 use Net::Works::Address ();
 use Net::Works::Network ();
 use Types::Common::String qw( NonEmptyStr );
 use Types::Standard qw( ArrayRef Bool );
 use Type::Utils qw( class_type );
-use WebService::PayPal::PaymentsAdvanced::Error::IPVerification;
+use WebService::PayPal::PaymentsAdvanced::Error::IPVerification ();
 
 extends 'WebService::PayPal::PaymentsAdvanced::Response';
 

--- a/lib/WebService/PayPal/PaymentsAdvanced/Response/SecureToken.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Response/SecureToken.pm
@@ -11,13 +11,12 @@ use feature qw( state );
 extends 'WebService::PayPal::PaymentsAdvanced::Response';
 
 use HTTP::Status qw( is_server_error );
-use Type::Params qw( compile );
 use Types::Standard qw( Bool CodeRef Enum InstanceOf Int );
 use Types::URI qw( Uri );
 use URI::QueryParam;
-use Web::Scraper;
-use WebService::PayPal::PaymentsAdvanced::Error::HTTP;
-use WebService::PayPal::PaymentsAdvanced::Error::HostedForm;
+use Web::Scraper qw( process scraper );
+use WebService::PayPal::PaymentsAdvanced::Error::HostedForm ();
+use WebService::PayPal::PaymentsAdvanced::Error::HTTP       ();
 
 has hosted_form_mode => (
     is        => 'ro',

--- a/lib/WebService/PayPal/PaymentsAdvanced/Role/HasTransactionTime.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Role/HasTransactionTime.pm
@@ -8,8 +8,8 @@ our $VERSION = '0.000028';
 
 use feature qw( state );
 
-use DateTime::TimeZone;
-use DateTime::Format::MySQL;
+use DateTime::TimeZone      ();
+use DateTime::Format::MySQL ();
 use Types::Standard qw( InstanceOf Maybe );
 
 has transaction_time => (

--- a/lib/WebService/PayPal/PaymentsAdvanced/Role/HasUA.pm
+++ b/lib/WebService/PayPal/PaymentsAdvanced/Role/HasUA.pm
@@ -6,7 +6,7 @@ use namespace::autoclean;
 
 our $VERSION = '0.000028';
 
-use LWP::UserAgent;
+use LWP::UserAgent ();
 use Types::Standard qw( InstanceOf );
 
 has ua => (

--- a/t/PaymentsAdvanced-live.t
+++ b/t/PaymentsAdvanced-live.t
@@ -3,17 +3,17 @@
 use strict;
 use warnings;
 
-use Data::GUID;
+use Data::GUID ();
 use LWP::ConsoleLogger::Easy qw( debug_ua );
 use LWP::UserAgent ();
 use Test::Fatal qw( exception );
 use Test::More;
 use Test::RequiresInternet( 'pilot-payflowpro.paypal.com' => 443 );
-use Try::Tiny;
-use WebService::PayPal::PaymentsAdvanced;
+use Try::Tiny qw( try );
+use WebService::PayPal::PaymentsAdvanced ();
 
 use lib 't/lib';
-use Util;
+use Util ();
 
 my $ua = LWP::UserAgent->new();
 debug_ua($ua);

--- a/t/PaymentsAdvanced.t
+++ b/t/PaymentsAdvanced.t
@@ -4,20 +4,20 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Fatal;
-use Test::LWP::UserAgent;
+use Test::Fatal qw( exception );
+use Test::LWP::UserAgent ();
 
 use HTTP::Message::PSGI;
 use HTTP::Response ();
 use LWP::ConsoleLogger::Easy qw( debug_ua );
 use LWP::UserAgent ();
 use Path::Tiny qw( path );
-use WebService::PayPal::PaymentsAdvanced;
-use WebService::PayPal::PaymentsAdvanced::Mocker;
+use WebService::PayPal::PaymentsAdvanced         ();
+use WebService::PayPal::PaymentsAdvanced::Mocker ();
 
 use lib 't/lib';
 use Secret ();
-use Util;
+use Util   ();
 
 ## no critic (ProhibitCallsToUnexportedSubs)
 {

--- a/t/PaymentsAdvanced/Mocker.t
+++ b/t/PaymentsAdvanced/Mocker.t
@@ -1,10 +1,9 @@
 use strict;
 use warnings;
 
-use Test::LWP::UserAgent;
 use Test::More;
 
-use WebService::PayPal::PaymentsAdvanced::Mocker;
+use WebService::PayPal::PaymentsAdvanced::Mocker ();
 
 for my $plack ( 1, 0 ) {
     {

--- a/t/PaymentsAdvanced/Mocker/SilentPOST.t
+++ b/t/PaymentsAdvanced/Mocker/SilentPOST.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Test::More;
 
-use WebService::PayPal::PaymentsAdvanced::Mocker::SilentPOST;
+use WebService::PayPal::PaymentsAdvanced::Mocker::SilentPOST ();
 
 my $post = WebService::PayPal::PaymentsAdvanced::Mocker::SilentPOST->new(
     secure_token_id => 'FOO' );

--- a/t/PaymentsAdvanced/Response.t
+++ b/t/PaymentsAdvanced/Response.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 
-use WebService::PayPal::PaymentsAdvanced::Response;
-use Test::Fatal;
+use WebService::PayPal::PaymentsAdvanced::Response ();
+use Test::Fatal qw( exception );
 use Test::More;
 
 my %params = (

--- a/t/PaymentsAdvanced/Response/FromHTTP.t
+++ b/t/PaymentsAdvanced/Response/FromHTTP.t
@@ -1,10 +1,10 @@
 use strict;
 use warnings;
 
-use HTTP::Response;
+use HTTP::Response ();
 use Test::Fatal qw( exception );
 use Test::More;
-use WebService::PayPal::PaymentsAdvanced::Response::FromHTTP;
+use WebService::PayPal::PaymentsAdvanced::Response::FromHTTP ();
 
 subtest '200 status code' => sub {
     my $http_response = HTTP::Response->new( 200, undef, undef, 'RESULT=0' );

--- a/t/PaymentsAdvanced/Response/FromRedirect.t
+++ b/t/PaymentsAdvanced/Response/FromRedirect.t
@@ -3,8 +3,7 @@ use warnings;
 
 use Test::More;
 use Test::Fatal qw( exception );
-use WebService::PayPal::PaymentsAdvanced;
-use WebService::PayPal::PaymentsAdvanced::Response::FromRedirect;
+use WebService::PayPal::PaymentsAdvanced ();
 
 my $payments = WebService::PayPal::PaymentsAdvanced->new(
     password => 'seekrit',

--- a/t/PaymentsAdvanced/Response/FromSilentPOST.t
+++ b/t/PaymentsAdvanced/Response/FromSilentPOST.t
@@ -3,12 +3,11 @@ use warnings;
 
 use Test::More;
 
-use Scalar::Util qw( blessed );
-use Test::Fatal;
+use Test::Fatal qw( exception );
 use WebService::PayPal::PaymentsAdvanced::Response::FromSilentPOST ();
 
 use lib 't/lib';
-use Util;
+use Util ();
 
 ## no critic (RequireExplicitInclusion)
 my $ppa = Util::mocked_ppa;

--- a/t/PaymentsAdvanced/Response/FromSilentPOST/CreditCard.t
+++ b/t/PaymentsAdvanced/Response/FromSilentPOST/CreditCard.t
@@ -5,10 +5,10 @@ use Test::More;
 
 use Scalar::Util qw( blessed );
 use Test::Fatal qw( exception );
-use WebService::PayPal::PaymentsAdvanced::Mocker::SilentPOST;
+use WebService::PayPal::PaymentsAdvanced::Mocker::SilentPOST ();
 
 use lib 't/lib';
-use Util;
+use Util ();
 
 ## no critic (ProhibitCallsToUnexportedSubs)
 ## no critic (RequireExplicitInclusion)

--- a/t/PaymentsAdvanced/Response/FromSilentPOST/PayPal.t
+++ b/t/PaymentsAdvanced/Response/FromSilentPOST/PayPal.t
@@ -4,10 +4,10 @@ use warnings;
 use Test::More;
 
 use Scalar::Util qw( blessed );
-use WebService::PayPal::PaymentsAdvanced::Mocker::SilentPOST;
+use WebService::PayPal::PaymentsAdvanced::Mocker::SilentPOST ();
 
 use lib 't/lib';
-use Util;
+use Util ();
 
 ## no critic (ProhibitCallsToUnexportedSubs)
 my $ppa    = Util::mocked_ppa;

--- a/t/PaymentsAdvanced/Response/SecureToken.t
+++ b/t/PaymentsAdvanced/Response/SecureToken.t
@@ -1,11 +1,11 @@
 use strict;
 use warnings;
 
-use HTTP::Response;
-use Test::Fatal;
-use Test::LWP::UserAgent;
+use HTTP::Response ();
+use Test::Fatal qw( exception );
+use Test::LWP::UserAgent ();
 use Test::More;
-use WebService::PayPal::PaymentsAdvanced::Response::SecureToken;
+use WebService::PayPal::PaymentsAdvanced::Response::SecureToken ();
 
 my %params = (
     RESULT        => 0,


### PR DESCRIPTION
I was trying to figure out why this dist relies on `Web::Scraper`. Initially it appeared to be unused, so I ran `perlimports` on it and it became clear that it is actually being used, but that the imports could use some tidying.